### PR TITLE
Relay enhancements

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+*   @mandrigin @revitteth @hexoscott

--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -213,7 +213,7 @@ func NewServer(port uint16, version uint8, systemID uint64, streamType StreamTyp
 	s.nextEntry = s.streamFile.header.TotalEntries
 
 	// Open (or create) the bookmarks DB
-	name := s.fileName[0:strings.IndexRune(s.fileName, '.')] + ".db"
+	name := s.fileName[:strings.LastIndex(s.fileName, ".")] + ".db"
 	s.bookmark, err = NewBookmark(name)
 	if err != nil {
 		return &s, err


### PR DESCRIPTION
This pull request introduces a new method to gracefully shut down the relay server and client, and includes a minor improvement to the bookmark database file naming. The most important changes are:

New method for graceful shutdown:

[datastreamer/streamrelay.go](https://github.com/0xPolygon/zkevm-data-streamer/pull/157/files#diff-8c25c642bdc155ea6986cc78df3d03d784d11b35194aa645bd0f35397bc428b3R116-R158): Added a Stop method to the StreamRelay struct to handle the graceful shutdown of both the relay client and server, including closing connections and stopping broadcasts.
Improvement to file naming:

[datastreamer/streamserver.go](https://github.com/0xPolygon/zkevm-data-streamer/pull/157/files#diff-2457b9c200e446fc7301fc62482f108751e6652e6dee2c2227172743fccec89eL216-R216): Modified the substring operation to use strings.LastIndex instead of strings.IndexRune to correctly handle file names when creating the bookmarks