### PR TITLE
feat: Add Noop command for keep-alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,15 @@ Command format sent by the client:
 
 If streaming already started or `bookmarkLength` exceeds the maximum length, terminates the connection.
 
+### Noop
+Sends a No-Operation command to the server. This is useful for keeping the TCP connection alive, preventing it from being closed due to inactivity by network intermediaries or the server's own inactivity timeout.
+
+Command format sent by the client:
+>u64 command = 7
+>u64 streamType // e.g. 1:Sequencer
+
+This command takes no additional parameters and only returns the standard Result entry.
+
 ### RESULT FORMAT (ResultEntry)
 Remember that all these TCP commands firstly return a response in the following detailed format:
 >u8 packetType // 0xff:Result  

--- a/datastreamer/streamclient.go
+++ b/datastreamer/streamclient.go
@@ -179,6 +179,12 @@ func (c *StreamClient) ExecCommandGetBookmark(fromBookmark []byte) (FileEntry, e
 	return entry, err
 }
 
+// ExecCommandNoop executes client TCP command to keep connection alive
+func (c *StreamClient) ExecCommandNoop() error {
+	_, _, err := c.execCommand(CmdNoop, false, 0, nil)
+	return err
+}
+
 // execCommand executes a valid client TCP command with deferred command result possibility
 func (c *StreamClient) execCommand(cmd Command, deferredResult bool,
 	fromEntry uint64, fromBookmark []byte) (HeaderEntry, FileEntry, error) {
@@ -249,6 +255,8 @@ func (c *StreamClient) execCommand(cmd Command, deferredResult bool,
 		if err != nil {
 			return header, entry, err
 		}
+	case CmdNoop:
+		// No parameters needed for Noop command
 	}
 
 	// Get the command result
@@ -284,6 +292,8 @@ func (c *StreamClient) execCommand(cmd Command, deferredResult bool,
 			return header, entry, ErrBookmarkNotFound
 		}
 		entry = e
+	case CmdNoop:
+		// No specific data response for Noop command
 	}
 
 	return header, entry, nil

--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -50,6 +50,7 @@ const (
 	CmdStartBookmark                    // CmdStartBookmark for the start from bookmark TCP client command
 	CmdEntry                            // CmdEntry for the get entry TCP client command
 	CmdBookmark                         // CmdBookmark for the get bookmark TCP client command
+	CmdNoop                             // CmdNoop for the keep-alive TCP client command
 )
 
 const (
@@ -94,6 +95,7 @@ var (
 		CmdStartBookmark: "StartBookmark",
 		CmdEntry:         "Entry",
 		CmdBookmark:      "Bookmark",
+		CmdNoop:          "Noop",
 	}
 
 	// StrCommandErrors for TCP command errors description
@@ -788,6 +790,9 @@ func (s *StreamServer) processCommand(command Command, client *client) error {
 	case CmdBookmark:
 		err = s.handleBookmarkCommand(cli)
 
+	case CmdNoop:
+		err = s.sendResultEntry(uint32(CmdErrOK), StrCommandErrors[CmdErrOK], client)
+
 	default:
 		log.Error("Invalid command!")
 		err = ErrInvalidCommand
@@ -1281,7 +1286,7 @@ func PrintResultEntry(e ResultEntry) {
 
 // IsACommand checks if a command is a valid command
 func (c Command) IsACommand() bool {
-	return c >= CmdStart && c <= CmdBookmark
+	return c >= CmdStart && c <= CmdNoop
 }
 
 // TimeoutWrite sets a deadline time before write


### PR DESCRIPTION
Introduces a new `CmdNoop` (code 7) to the datastreamer TCP protocol.

This command allows clients to send a no-operation message to the server, primarily intended to keep the TCP connection alive and prevent timeouts due to inactivity.

Changes include:
- Defined `CmdNoop` constant and added handling in `streamserver.go`.
- Added `ExecCommandNoop` function to `streamclient.go`.
- Updated the `IsACommand` validity check to include `CmdNoop`.
- Documented the new command in `README.md`.