### PR TITLE
tweak to add me to CODEOWNERS and relocate to .github

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,1 @@
-.github                 @ToniRamirezM
-*.md                    @agnusmor @dpunish3r
-cmd/                    @dpunish3r
-datastreamer/           @dpunish3r
-doc/                    @agnusmor @dpunish3r
-log/                    @dpunish3r @ToniRamirezM
+*   @mandrigin @revitteth @hexoscott @ppttf

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-*   @mandrigin @revitteth @hexoscott


### PR DESCRIPTION
This pull request updates ownership assignments in the `CODEOWNERS` files. The changes consolidate and simplify the ownership structure by replacing specific file and directory ownership rules with a single, unified rule.

Ownership updates:

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Replaced detailed ownership rules for specific files and directories with a single rule assigning ownership to `@mandrigin`, `@revitteth`, `@hexoscott`, and `@ppttf`.
* [`CODEOWNERS`](diffhunk://#diff-fcf14c4b7b34fe7a11916195871ae66a59be87a395f28db73e345ebdc828085bL1): Removed the existing ownership rule for all files, which previously assigned ownership to `@mandrigin`, `@revitteth`, and `@hexoscott`.