### PR TITLE
Update CODEOWNERS for new account name

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @mandrigin @revitteth @hexoscott @ppttf
+*   @mandrigin @revitteth @hexoscott @tamingchaos


### PR DESCRIPTION
This pull request updates the `.github/CODEOWNERS` file to reflect a change in username.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7L1-R1): Replaced `@ppttf` with `@tamingchaos` in the list of repository code owners.
