### PR TITLE
Update Go version to 1.25

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.21.x
+          go-version: 1.25
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@
       test:
         strategy:
           matrix:
-            go-version: [ 1.21.x ]
+            go-version: [ 1.25 ]
             goarch: [ "amd64" ]
         runs-on: ubuntu-latest
         steps:
@@ -30,7 +30,7 @@
 
 
         - name: Archive code coverage results
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: code-coverage-report
             path: coverage.out
@@ -47,7 +47,7 @@
               fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
           - name: Download code coverage results
-            uses: actions/download-artifact@v3
+            uses: actions/download-artifact@v4
             with:
               name: code-coverage-report
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # CONTAINER FOR BUILDING BINARY
-FROM golang:1.21 AS build
+FROM golang:1.25 AS build
 
 # INSTALL DEPENDENCIES
 RUN go install github.com/gobuffalo/packr/v2/packr2@v2.8.3

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,6 @@ module github.com/gateway-fm/zkevm-data-streamer
 
 go 1.25
 
-toolchain go1.25.0
 
 require (
 	github.com/ethereum/go-ethereum v1.14.13

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,8 @@
 module github.com/gateway-fm/zkevm-data-streamer
 
-go 1.22
-toolchain go1.24.1
+go 1.25
+
+toolchain go1.25.0
 
 require (
 	github.com/ethereum/go-ethereum v1.14.13


### PR DESCRIPTION
This pull request updates the project to use Go version 1.25 across the build, test, and lint workflows, ensuring consistency and compatibility with the latest language features. It also upgrades the GitHub Actions used for uploading and downloading artifacts to v4 for improved reliability and performance.

**Go version updates:**
* Updated Go version to 1.25 in the `Dockerfile`, `.github/workflows/lint.yml`, and `.github/workflows/test.yml` to standardize the environment and leverage new language improvements. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L2-R2) [[2]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L17-R17) [[3]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L13-R13) [[4]](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L3-R5)

**GitHub Actions upgrades:**
* Upgraded `actions/upload-artifact` and `actions/download-artifact` from v3 to v4 in `.github/workflows/test.yml` for better performance and support. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L33-R33) [[2]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L50-R50)