### PR TITLE
Add Close methods for StreamBookmark, StreamFile, and StreamServer to…

### DIFF
--- a/datastreamer/streambookmark.go
+++ b/datastreamer/streambookmark.go
@@ -105,8 +105,10 @@ func (b *StreamBookmark) PrintDump() error {
 }
 
 func (b *StreamBookmark) Close() error {
-	if b.db != nil {
-		return b.db.Close()
+	if b.db == nil {
+		return nil
 	}
-	return nil
+	err := b.db.Close()
+	b.db = nil
+	return err
 }

--- a/datastreamer/streambookmark.go
+++ b/datastreamer/streambookmark.go
@@ -103,3 +103,10 @@ func (b *StreamBookmark) PrintDump() error {
 
 	return err
 }
+
+func (b *StreamBookmark) Close() error {
+	if b.db != nil {
+		return b.db.Close()
+	}
+	return nil
+}

--- a/datastreamer/streamfile.go
+++ b/datastreamer/streamfile.go
@@ -1080,17 +1080,19 @@ func (f *StreamFile) truncateFile(entryNum uint64) error {
 }
 
 func (f *StreamFile) Close() error {
-	if f.file != nil {
-		// Write updated header (includes totalEntries count)
-		if err := f.writeHeaderEntry(); err != nil {
-			return err
-		}
-		// Flush data to disk
-		if err := f.file.Sync(); err != nil {
-			return err
-		}
-		// Close the file
-		return f.file.Close()
+	if f.file == nil {
+		return nil
 	}
-	return nil
+	// Write updated header (includes totalEntries count)
+	if err := f.writeHeaderEntry(); err != nil {
+		return err
+	}
+	// Flush data to disk
+	if err := f.file.Sync(); err != nil {
+		return err
+	}
+	// Close the file
+	err := f.file.Close()
+	f.file = nil
+	return err
 }

--- a/datastreamer/streamfile.go
+++ b/datastreamer/streamfile.go
@@ -1078,3 +1078,19 @@ func (f *StreamFile) truncateFile(entryNum uint64) error {
 
 	return nil
 }
+
+func (f *StreamFile) Close() error {
+	if f.file != nil {
+		// Write updated header (includes totalEntries count)
+		if err := f.writeHeaderEntry(); err != nil {
+			return err
+		}
+		// Flush data to disk
+		if err := f.file.Sync(); err != nil {
+			return err
+		}
+		// Close the file
+		return f.file.Close()
+	}
+	return nil
+}


### PR DESCRIPTION
This pull request introduces graceful shutdown functionality to the data streaming subsystem, ensuring all resources are properly released when closing. The main changes add `Close` methods to key components and update server routines to handle shutdown scenarios safely.

Resource management and graceful shutdown:

* Added a `Close` method to `StreamServer` that cleanly shuts down the server, closes the network listener, disconnects clients, closes internal channels, and releases file and bookmark resources. Errors are aggregated and reported. (`datastreamer/streamserver.go`)
* Implemented `Close` methods for both `StreamFile` and `StreamBookmark` to flush data, update headers, and close underlying resources safely. (`datastreamer/streamfile.go`, `datastreamer/streambookmark.go`) [[1]](diffhunk://#diff-24006990a777e9734c11c4ea30e76243458a28a381bf140217ba4f661069c8e7R1081-R1096) [[2]](diffhunk://#diff-c25939042610a6a708b9cff0288400a188a8c6c6c61449f7f958d9a0242f1530R106-R112)

Server routine robustness:

* Updated the client inactivity checker and connection accept loop in `StreamServer` to exit cleanly if the server is shutting down, preventing goroutine leaks and errors during shutdown. (`datastreamer/streamserver.go`) [[1]](diffhunk://#diff-2457b9c200e446fc7301fc62482f108751e6652e6dee2c2227172743fccec89eR270-R274) [[2]](diffhunk://#diff-2457b9c200e446fc7301fc62482f108751e6652e6dee2c2227172743fccec89eR300-R303)