### PR TITLE
Improve shutdown handling in StreamServer

### DIFF
--- a/datastreamer/streamserver.go
+++ b/datastreamer/streamserver.go
@@ -293,12 +293,19 @@ func (s *StreamServer) checkClientInactivity() {
 
 // waitConnections waits for a new client connection and creates a goroutine to manages it
 func (s *StreamServer) waitConnections() {
-	defer s.ln.Close()
+
+	// capture listener locally to avoid race / nil deref if s.Close() sets s.ln = nil
+	ln := s.ln
+	if ln == nil {
+		return
+	}
+
+	defer ln.Close()
 
 	const timeout = 2 * time.Second
 
 	for {
-		conn, err := s.ln.Accept()
+		conn, err := ln.Accept()
 		if err != nil {
 			// Exit loop if listener is closed
 			if errors.Is(err, net.ErrClosed) {
@@ -1472,7 +1479,6 @@ func (s *StreamServer) Close() error {
 		if err := s.ln.Close(); err != nil {
 			errs = append(errs, fmt.Errorf("failed to close listener: %w", err))
 		}
-		s.ln = nil
 	}
 
 	// 2. Disconnect and cleanup all clients


### PR DESCRIPTION
This pull request improves the stability and safety of the `StreamServer` by addressing potential race conditions and nil pointer dereferences related to the network listener (`s.ln`). The main focus is on ensuring that the listener is handled safely during shutdown and client connection acceptance.

Listener management improvements:

* In `waitConnections`, the listener (`s.ln`) is now captured into a local variable at the start of the function. This avoids race conditions and possible nil pointer dereferences if `s.Close()` sets `s.ln` to nil while connections are being accepted. The function also now checks if the listener is nil before proceeding.
* The line that sets `s.ln = nil` in `Close()` has been removed, reducing the risk of concurrent access issues and making listener lifecycle management more predictable.