### PR TITLE
Add all R&D members to CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @mandrigin @revitteth @hexoscott @tamingchaos
+*   @mandrigin @revitteth @hexoscott @tamingchaos @IvanBelyakoff @elliothllm


### PR DESCRIPTION
This pull request makes a small update to the `.github/CODEOWNERS` file by adding two new users as code owners.