### PR TITLE
Remove hexoscott from codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @mandrigin @revitteth @hexoscott @tamingchaos @IvanBelyakoff @elliothllm
+*   @mandrigin @revitteth @tamingchaos @IvanBelyakoff @elliothllm


### PR DESCRIPTION
Closes https://linear.app/gateway-fm/issue/RD-640/remove-scott-from-code-owners-across-randd-repos